### PR TITLE
Change to use machine api

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: access-machine-info-cr
 rules:
-- apiGroups: [""]
+- apiGroups: ["machine.openshift.io"]
   resources: ["machines"]
-  resourceNames: [ "*" ]
   verbs: ["get", "list"]
 ---
 kind: RoleBinding

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: allow-deploy-access-to-cluster-info
+  name: allow-deploy-access-to-machine-info
   namespace: openshift-machine-api
 subjects:
 - kind: ServiceAccount

--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ The operations are related to writing cluster ID, AWS region name, and AWS API c
 
 Due to Kubernetes limitations, [ConfigMaps](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/) can't be used (as volumes) across namespaces. Cluster information resides in the `kube-system` namespace (or sometimes `kube-public`) and on OpenShift Dedicated, the `kube-system/configmap/cluster-config-v1` ConfigMap has two pieces of information that we'd like to access, the cluster's ID and the AWS region in which it runs.
 
+An additional complication is the `kube-system/configmap/cluster-config-v1` is deprecated and thus we must find a different avenue for the pieces of data we care about. In the interim, we can rely on the `Machine` object(s) from the `openshift-machine-api` namespace.
+
 There is a further desire to rely on the [cloud-credential-operator](https://github.com/openshift/cloud-credential-operator) to request AWS credentials at runtime.
 
-### Accessing Cluster Information ConfigMap
+### Accessing Cluster Information
 
-To get access to the cluster information ConfigMap we could change our main container to access this information, but those initialization tasks are best suited to init containers. To that end, the [ServiceAccount](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) for the Pod must be granted access to the aforementioned ConfigMap by [ClusterRole and RoleBinding](https://kubernetes.io/docs/reference/access-authn-authz/rbac/). A sample one follows:
+To get access to the cluster information ConfigMap and other objects we could change our main container to access this information, but those initialization tasks are best suited to init containers. To that end, the [ServiceAccount](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) for the Pod must be granted access to the aforementioned objects by [ClusterRole and RoleBinding](https://kubernetes.io/docs/reference/access-authn-authz/rbac/). A sample one follows:
 
 ```yaml
 ---
@@ -25,19 +27,18 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: access-cluster-info-cr
+  name: access-machine-info-cr
 rules:
 - apiGroups: [""]
-  resources: ["configmaps"]
-  resourceNames:
-    - cluster-config-v1
+  resources: ["machines"]
+  resourceNames: [ "*" ]
   verbs: ["get", "list"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: allow-deploy-access-to-cluster-info
-  namespace: kube-system
+  namespace: openshift-machine-api
 subjects:
 - kind: ServiceAccount
   name: pod-sa
@@ -45,7 +46,7 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: access-cluster-info-cr
+  name: access-machine-info-cr
 ```
 
 ### AWS Credentials

--- a/fetch.sh
+++ b/fetch.sh
@@ -231,7 +231,7 @@ if [[ -n $do_region || -n $do_accesskey || -n $do_secretkey ]]; then
 fi
 
 if [[ -n $do_region || -n $do_clusterid ]]; then
-  raw_configmap=$(mktemp -t XXXXX)
+  raw_configmap=$(mktemp)
   if [[ $? -ne 0 ]]; then
     err "Couldn't allocate a temporary YAML file"
     exit 1

--- a/fetch.sh
+++ b/fetch.sh
@@ -66,7 +66,7 @@ ensure_directory() {
 }
 
 get_raw_yamlobj() {
-  local tokenfile=$1 namespace=$2 getcmd="$3" destination=$4 
+  local tokenfile=$1 namespace=$2 getcmd=$3 destination=$4 
   kubectl --token=$(cat $tokenfile) --insecure-skip-tls-verify=true -n $namespace $getcmd -o yaml 2> /dev/null 1> $destination 
   if [[ $? -ne 0 ]]; then
     err "Couldn't get the raw configmap."
@@ -165,7 +165,7 @@ do_secretkey=
 # temp file
 raw_configmap=
 
-while getopts ":hn:c:r:a:A:o:t:q:Q:" opt; do
+while getopts ":hn:y:c:r:a:A:o:t:q:Q:" opt; do
   case $opt in
     h)
       usage

--- a/fetch.sh
+++ b/fetch.sh
@@ -66,8 +66,8 @@ ensure_directory() {
 }
 
 get_raw_yamlobj() {
-  local tokenfile=$1 namespace=$2 getcmd=$3 destination=$4 
-  kubectl --token=$(cat $tokenfile) --insecure-skip-tls-verify=true -n $namespace  get $getcmd -o yaml 2> /dev/null 1> $destination 
+  local tokenfile=$1 namespace=$2 getcmd="$3" destination=$4 
+  kubectl --token=$(cat $tokenfile) --insecure-skip-tls-verify=true -n $namespace $getcmd -o yaml 2> /dev/null 1> $destination 
   if [[ $? -ne 0 ]]; then
     err "Couldn't get the raw configmap."
     exit 1
@@ -236,7 +236,7 @@ if [[ -n $do_region || -n $do_clusterid ]]; then
     err "Couldn't allocate a temporary YAML file"
     exit 1
   fi
-  get_raw_yamlobj $tokenfile $namespace $yamldump $raw_configmap
+  get_raw_yamlobj $tokenfile $namespace "${yamldump}" $raw_configmap
 fi
 
 if [[ -n $do_clusterid ]]; then


### PR DESCRIPTION
The previous cluster-config-v1 configmap is deprecated and the interim
suggestion is to use the Machine api (until something more mature is
developed). To that end, I have abstracted somewhat the way in which the
data is accessed. Instead of being fixed to a configmap, the user may
instead pass whatever kubectl fragment (eg `get machines`) as well as
the `yq` expressions that match, so that when the next data source(s)
are available, the transition will be easier.

